### PR TITLE
Begin syntax. WARNING: New syntax.

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "FieldMetadata"
 uuid = "bf96fef3-21d2-5d20-8afa-0e7d4c32a885"
 authors = ["Rafael Schouten <rafaelschouten@gmail.com>"]
-version = "0.1.1"
+version = "0.2.0"
 
 [compat]
 julia = "1"

--- a/README.md
+++ b/README.md
@@ -11,9 +11,14 @@ You can use it as a minimalist replacement for Parameters.jl with the aid of
 FieldMetadata on nested structs can be flattened into a vector or tuple very efficiently with [Flatten.jl](https://github.com/rafaqz/Flatten.jl), where they are also used to 
 exclude fields from flattening.
 
+__NOTIFICATION:__ There have been major syntax changes for v0.2. Read the
+examples below for the new syntax.
+
+
 This example that adds string description metadata to fields in a struct:
 
 ```julia
+using FieldMetadata
 @metadata describe ""
 
 @describe mutable struct Described
@@ -23,13 +28,13 @@ end
 
 d = Described(1, 1.0)
 
-julia>describe(d, :a) 
+julia> describe(d, :a) 
 "an Int with a description"  
 
-julia>describe(d, :b) 
+julia> describe(d, :b) 
 "a Float with a description"  
 
-julia>describe(d, :c) 
+julia> describe(d, :c) 
 ""  
 ```
 
@@ -40,7 +45,7 @@ using Parameters
 @metadata describe ""
 @metadata limits (0, 1)
 
-@describe @limits @with_kw struct WithKeyword{T}
+@limits @describe @with_kw struct WithKeyword{T}
     a::T = 3 | (0, 100) | "a field with a range, description and default"
     b::T = 5 | (2, 9)   | "another field with a range, description and default"
 end
@@ -50,23 +55,23 @@ k = WithKeyword()
 julia> describe(k, :b) 
 "another field with a range, description and default"
 
-julia> paramrange(k, :a) 
+julia> limits(k, :a) 
 [0, 100]
 ""  
 ```
 
-You can chain as many metadata macros together as you want. Just remember that 
-the data for the first `@metadata` macro goes at the end on the
-line in the struct. This makes sense when you consider that a macro like
-@with_kw from Parameters.jl has to be the last macro, but the first item in the
-row after the field type.
+You can chain as many metadata macros together as you want. As of
+FieldMetadata.jl v0.2, macros are written in the same order as the metadata
+columns, as opposed to the opposite order which was the syntax in v0.1
+
+However, @with_kw from Parameters.jl must be the last macro and the first field, 
+if it is used.
 
 You can also update or add fields on a type that is already declared using a
 `begin` block syntax. You don't need to include all fields or their types.
 
-This is a change from the previous syntax in 0.1, where `@re` was prepended
-to update using the same struct syntax. There are a number of benefits to this,
-firstly that we can use typeof(x) instead of the type name.
+This is another change from the syntax in v0.1, where `@re` was prepended
+to update using the same struct syntax.
 
 ```julia
 julia> describe(d)                                                                                                     
@@ -80,6 +85,18 @@ julia> d = Described(1, 1.0)
 
 julia> describe(d)
 ("an Int with a description", "a much better description")
+```
+
+We can use `typeof(x)` and a little meta-programming instead of the type name, 
+which can be useful for anonymous function parameters:
+
+```
+@describe :($(typeof(d))) begin
+   a | "a description without using the type"
+end
+
+julia> describe(d)
+("a description without using the type", "a much better desc ription")
 ```
 
 
@@ -104,10 +121,12 @@ packages:
 To use them, call:
 
 ```julia
-import FieldMetadata: @prior, @reprior, prior
+import FieldMetadata: @prior, prior
 ```
 
 You _must_ `import` at least the function to use these placeholders, `using` is
-not enough as you are effectively adding methods for you own types. Calling
-`@reprior` or similar on someone elses struct is type piracy and shouldn't be
-done in a published package, but can be useful in scripts.
+not enough as you are effectively adding methods for you own types. 
+
+Calling `@prior` or similar on someone else's struct may be type piracy and
+shouldn't be done in a published package unless the macro is also defined there.
+However, it can be useful in scripts.

--- a/README.md
+++ b/README.md
@@ -61,15 +61,18 @@ line in the struct. This makes sense when you consider that a macro like
 @with_kw from Parameters.jl has to be the last macro, but the first item in the
 row after the field type.
 
-You can also update or add fields on a type that is already declared using the
-same syntax, by prepending `re` to the start of the macro, like `@redescribe`.
-You don't need to include all fields or their types.
+You can also update or add fields on a type that is already declared using a
+`begin` block syntax. You don't need to include all fields or their types.
+
+This is a change from the previous syntax in 0.1, where `@re` was prepended
+to update using the same struct syntax. There are a number of benefits to this,
+firstly that we can use typeof(x) instead of the type name.
 
 ```julia
 julia> describe(d)                                                                                                     
 ("an Int with a description", "a Float with a description")  
 
-@redescribe struct Described
+@describe Described begin
    b | "a much better description"
 end
 

--- a/src/FieldMetadata.jl
+++ b/src/FieldMetadata.jl
@@ -238,14 +238,13 @@ namify(x::Expr) = namify(x.args[1])
 @metadata default nothing
 @metadata units 1
 @metadata prior nothing
-@metadata description ""
-@metadata limits (1e-7, 1.0) # just above zero so log transform is possible 
-@metadata bounds (1e-7, 1.0) # just above zero so log transform is possible 
 @metadata label ""
+@metadata description ""
+@metadata limits (0.0, 1.0)
+@metadata bounds (0.0, 1.0)
 @metadata logscaled false
 @metadata flattenable true
 @metadata plottable true
-@metadata selectable Nothing
 
 # Set the default label to be the field name
 label(x::Type, ::Type{Val{F}}) where F = F

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -105,11 +105,14 @@ m = MissingKeyword(b = 99)
 @test m.b == 99
 @test paramrange(m) == ([0, 100], [2, 9])
 
+@metadata default nothing
+
 # update description
 @reparamrange @redescription mutable struct Described{T}
     a::T | "a new Int description"     | [99,100]
     b    | "a new Float64 description" | [-3,-4]
 end
+
 
 @test paramrange(d, :a) == [99,100]
 @test paramrange(d, :b) == [-3,-4]
@@ -118,6 +121,15 @@ end
 @inferred description(d, :a)
 @inferred description(d, :b)
 
+@paramrange @description @default Described begin 
+    a | 1 | "a description updated in a begin block" | [22,33]
+    b | 2 | "another updated description"            | [-8,-9]
+end
+
+@test paramrange(d, :a) == [22,33]
+@test paramrange(d, :b) == [-8,-9]
+@test description(d, :a) == "a description updated in a begin block"
+@test description(d, :b) == "another updated description"
 
 # docstrings
 "The Docs"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,7 +2,7 @@ using FieldMetadata, Parameters, Test, Markdown, REPL
 
 abstract type AbstractTest end
 
-import FieldMetadata: @description, @redescription, description
+import FieldMetadata: @description, description
 
 @metadata paramrange [0, 1]
 
@@ -18,6 +18,9 @@ import FieldMetadata: @description, @redescription, description
        new{Nothing}(a, b, nothing)
    end
 end
+
+@test length(methods(Described).ms) == 2
+@test length(methods(description).ms) == 12
 
 d = Described(1, 1.0, nothing)
 @test typeof(d) == typeof(Described(1, 1.0))
@@ -65,9 +68,9 @@ w = WithRange(2,5)
 
 
 # combinations of metadata
-@description @paramrange struct Combined{T} <: AbstractTest
-    a::T | [1, 4]  | "an Int with a range and a description"
-    b::T | _       | "a Float with a range and a description"
+@paramrange @description struct Combined{T} <: AbstractTest
+    a::T | [1, 4] | "an Int with a range and a description"
+    b::T | _      | "a Float with a range and a description"
 end
 
 c = Combined(3,5)
@@ -79,7 +82,7 @@ description(c, Val{:a})
 
 
 # with Parameters.jl keywords
-@description @paramrange @with_kw struct Keyword{T} <: AbstractTest
+@paramrange @description @with_kw struct Keyword{T} <: AbstractTest
     a::T = 3 | [0, 100] | "an Int with a range and a description"
     b::T = 5 | [2, 9]   | "a Float with a range and a description"
 end
@@ -92,7 +95,7 @@ k = Keyword()
 
 
 # with missing keywords
-@description @paramrange @with_kw struct MissingKeyword{T} <: AbstractTest
+@paramrange @description @with_kw struct MissingKeyword{T} <: AbstractTest
     a    = 3 | [0, 100] | "an Int with a range and a description"
     b::T     | [2, 9]   | "a Float with a range and a description"
     MissingKeyword{T}(a::T, b::T) where T = new{T}(a, b)
@@ -107,21 +110,7 @@ m = MissingKeyword(b = 99)
 
 @metadata default nothing
 
-# update description
-@reparamrange @redescription mutable struct Described{T}
-    a::T | "a new Int description"     | [99,100]
-    b    | "a new Float64 description" | [-3,-4]
-end
-
-
-@test paramrange(d, :a) == [99,100]
-@test paramrange(d, :b) == [-3,-4]
-@test description(d, :a) == "a new Int description"
-@test description(d, :b) == "a new Float64 description"
-@inferred description(d, :a)
-@inferred description(d, :b)
-
-@paramrange @description @default Described begin 
+@default @description @paramrange Described begin 
     a | 1 | "a description updated in a begin block" | [22,33]
     b | 2 | "another updated description"            | [-8,-9]
 end
@@ -130,6 +119,29 @@ end
 @test paramrange(d, :b) == [-8,-9]
 @test description(d, :a) == "a description updated in a begin block"
 @test description(d, :b) == "another updated description"
+
+# Now eval in all the values
+def_a = 3
+def_b = 4
+desc_a = "interpolated string a"
+desc_b = "interpolated string b"
+vec_a = [0, 0]
+vec_b = [1, 1]
+
+@eval   @default   @description   @paramrange :($(typeof(d))) begin 
+    a | $def_a   | $desc_a      | $vec_a
+    b | $def_b   | $desc_b      | $vec_b
+end
+
+@test default(d, :a) == 3
+@test default(d, :b) == 4
+@test paramrange(d, :a) == [0, 0]
+@test paramrange(d, :b) == [1, 1]
+@test description(d, :a) == "interpolated string a"
+@test description(d, :b) == "interpolated string b"
+
+def_a = 44
+@test default(d, :a) == 3
 
 # docstrings
 "The Docs"
@@ -149,9 +161,9 @@ end
 
 # chaining macros
 
-@chain columns @reparamrange @redescription
+@chain columns @description @paramrange 
 
-@columns mutable struct Described{T}
+@columns Described begin
     a::T | "a new Int description"     | [99,100]
     b::T | "a new Float64 description" | [-3,-4]
 end


### PR DESCRIPTION
This pull request makes a number of syntax major changes.

Macros are now written in the same order as the fields. This should be less confusing, but will break all current uses.

`@re`- macros are gone. Now we just use the same macro name but on a begin block to update the fields. This is also a breaking change, but I think better in the long term.